### PR TITLE
implement hostname on windows

### DIFF
--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -159,6 +159,8 @@ set(utility_SOURCES
   po.hpp po.cpp
 
   vercmp.hpp vercmp.cpp
+
+  hostname.hpp # implementation is system dependent
   )
 
 # system-dependent stuff
@@ -221,6 +223,7 @@ if(WIN32)
     detail/filedes.windows.cpp
     detail/limits.unsupported.cpp
     detail/unistd_compat.windows.cpp
+    detail/hostname.windows.cpp
     )
 
 else()
@@ -233,11 +236,11 @@ else()
     lockfile.hpp lockfile.cpp
     identity.hpp identity.cpp
     persona.hpp switchpersona.cpp
-    hostname.hpp hostname.cpp
 
     detail/limits.posix.cpp
     detail/time.posix.cpp
     detail/filedes.posix.cpp
+    detail/hostname.linux.cpp
     )
 endif()
 

--- a/utility/detail/hostname.linux.cpp
+++ b/utility/detail/hostname.linux.cpp
@@ -28,7 +28,7 @@
 
 #include <climits>
 
-#include "hostname.hpp"
+#include "../hostname.hpp"
 
 namespace utility {
 

--- a/utility/detail/hostname.windows.cpp
+++ b/utility/detail/hostname.windows.cpp
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2021 Melown Technologies SE
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * *  Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <Windows.h>
+
+#include "../hostname.hpp"
+
+namespace utility {
+
+std::string hostname()
+{
+    constexpr size_t HOST_NAME_MAX = 256;
+    char hn[HOST_NAME_MAX + 1] = {};
+    DWORD siz = HOST_NAME_MAX;
+    ::GetComputerNameA(hn, &siz); // gethostname is also available but requires WSAStartup
+    return std::string(hn);
+}
+
+} // namespace utility

--- a/utility/process.cpp
+++ b/utility/process.cpp
@@ -581,7 +581,7 @@ int systemImpl(const std::string &program, ProcessExecContext ctx)
     // build arguments
     ExecArgs argv;
     argv.arg(program);
-    for (const auto arg : ctx.argv) {
+    for (const auto &arg : ctx.argv) {
         if (arg) {
             argv.arg(*arg);
         }
@@ -613,7 +613,7 @@ void execImpl(const std::string &program, ProcessExecContext ctx)
     // build arguments
     ExecArgs argv;
     argv.arg(program);
-    for (const auto arg : ctx.argv) {
+    for (const auto &arg : ctx.argv) {
         if (arg) {
             argv.arg(*arg);
         }


### PR DESCRIPTION
GetComputerName and gethostname return same string on my computer, but i do not know if that is always the case.
However, gethostname would require WSAStartup (initializes networking in the process) which may trigger firewall actions etc.
Furthermore, gethostname requires linking additional library.
Therefore I opted to use GetComputerName.