### PR TITLE
fdqn() function to accompany existing `hostname()

### DIFF
--- a/utility/detail/hostname.windows.cpp
+++ b/utility/detail/hostname.windows.cpp
@@ -39,4 +39,10 @@ std::string hostname()
     return std::string(hn);
 }
 
+std::string fqdn()
+{
+    // TODO: implement me
+    return {}
+}
+
 } // namespace utility

--- a/utility/hostname.hpp
+++ b/utility/hostname.hpp
@@ -33,6 +33,8 @@ namespace utility {
 
 std::string hostname();
 
+std::string fqdn();
+
 } // namespace utility
 
 #endif // utility_hostname_hpp_included_


### PR DESCRIPTION
`utility::fqdn()` works exactly as `hostname -f`: gets localhost's hostname and runs it through `getaddrinfo` to get canonical name.
See `-f` option documentation in `man hostname` for more details.