### PR TITLE
process: support for non-truncated file redirect

### DIFF
--- a/utility/detail/redirectfile.hpp
+++ b/utility/detail/redirectfile.hpp
@@ -41,11 +41,11 @@ struct RedirectFile {
     enum class Direction { in, outTruncate, out };
 
     struct SrcPath {
-        SrcPath(const boost::filesystem::path &path, Direction out)
-            : path(path), out(out) {}
+        SrcPath(const boost::filesystem::path &path, Direction dir)
+            : path(path), dir(dir) {}
         boost::filesystem::path path;
 
-        Direction out;
+        Direction dir;
     };
 
     struct DstArg {
@@ -67,11 +67,10 @@ struct RedirectFile {
         : dst(dst), dstType(DstType::fd)
         , src(src), srcType(SrcType::fd) {}
     RedirectFile(int dst, const boost::filesystem::path &path
-                 , Direction out)
+                 , Direction dir)
         : dst(dst), dstType(DstType::fd)
-        , src(SrcPath(path, out)), srcType(SrcType::path) {}
-    RedirectFile(int dst, const boost::filesystem::path &path
-                 , bool out)
+        , src(SrcPath(path, dir)), srcType(SrcType::path) {}
+    RedirectFile(int dst, const boost::filesystem::path &path, bool out)
         : RedirectFile
           (dst, path, out ? Direction::outTruncate : Direction::in)
     {}

--- a/utility/detail/redirectfile.hpp
+++ b/utility/detail/redirectfile.hpp
@@ -38,11 +38,14 @@ namespace utility { namespace detail {
 class SystemContext;
 
 struct RedirectFile {
+    enum class Direction { in, outTruncate, out };
+
     struct SrcPath {
-        SrcPath(const boost::filesystem::path &path, bool out)
+        SrcPath(const boost::filesystem::path &path, Direction out)
             : path(path), out(out) {}
         boost::filesystem::path path;
-        bool out;
+
+        Direction out;
     };
 
     struct DstArg {
@@ -63,9 +66,15 @@ struct RedirectFile {
     RedirectFile(int dst, int src)
         : dst(dst), dstType(DstType::fd)
         , src(src), srcType(SrcType::fd) {}
-    RedirectFile(int dst, const boost::filesystem::path &path, bool out)
+    RedirectFile(int dst, const boost::filesystem::path &path
+                 , Direction out)
         : dst(dst), dstType(DstType::fd)
         , src(SrcPath(path, out)), srcType(SrcType::path) {}
+    RedirectFile(int dst, const boost::filesystem::path &path
+                 , bool out)
+        : RedirectFile
+          (dst, path, out ? Direction::outTruncate : Direction::in)
+    {}
     RedirectFile(int dst, std::istream &is)
         : dst(dst), dstType(DstType::fd)
         , src(&is), srcType(SrcType::istream) {}

--- a/utility/process.cpp
+++ b/utility/process.cpp
@@ -180,7 +180,7 @@ void redirect(const ProcessExecContext::Redirects &redirects)
 
             auto src(boost::any_cast<RedirectFile::SrcPath>(redirect.src));
             int fd(-1);
-            switch (src.out) {
+            switch (src.dir) {
             case RedirectFile::Direction::in:
                 fd = ::open(src.path.string().c_str(), O_RDONLY);
                 break;

--- a/utility/process.cpp
+++ b/utility/process.cpp
@@ -180,12 +180,20 @@ void redirect(const ProcessExecContext::Redirects &redirects)
 
             auto src(boost::any_cast<RedirectFile::SrcPath>(redirect.src));
             int fd(-1);
-            if (src.out) {
+            switch (src.out) {
+            case RedirectFile::Direction::in:
+                fd = ::open(src.path.string().c_str(), O_RDONLY);
+                break;
+            case RedirectFile::Direction::outTruncate:
                 fd = ::open(src.path.string().c_str()
                             , O_WRONLY | O_CREAT | O_TRUNC
                             , (S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH));
-            } else {
-                fd = ::open(src.path.string().c_str(), O_RDONLY);
+                break;
+            case RedirectFile::Direction::out:
+                fd = ::open(src.path.string().c_str()
+                            , O_WRONLY | O_CREAT
+                            , (S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH));
+                break;
             }
 
             if (fd == -1) {

--- a/utility/process.hpp
+++ b/utility/process.hpp
@@ -68,8 +68,13 @@ struct Stdout : detail::RedirectFile {
 
 struct Stderr : detail::RedirectFile {
     explicit Stderr(int fd) : RedirectFile(STDERR_FILENO, fd) {}
-    explicit Stderr(const boost::filesystem::path &path)
-        : RedirectFile(STDERR_FILENO, path, true) {}
+    explicit Stderr(const boost::filesystem::path &path
+                    , bool truncate = true)
+        : RedirectFile(STDERR_FILENO, path
+                       , (truncate
+                          ? detail::RedirectFile::Direction::outTruncate
+                          : detail::RedirectFile::Direction::out))
+    {}
     explicit Stderr(std::ostream &os) : RedirectFile(STDERR_FILENO, os) {}
 
     friend class ProcessExecContext;

--- a/utility/process.hpp
+++ b/utility/process.hpp
@@ -54,8 +54,13 @@ struct Stdin : detail::RedirectFile {
 
 struct Stdout : detail::RedirectFile {
     explicit Stdout(int fd) : RedirectFile(STDOUT_FILENO, fd) {}
-    explicit Stdout(const boost::filesystem::path &path)
-        : RedirectFile(STDOUT_FILENO, path, true) {}
+    explicit Stdout(const boost::filesystem::path &path
+                    , bool truncate = true)
+        : RedirectFile(STDOUT_FILENO, path
+                       , (truncate
+                          ? detail::RedirectFile::Direction::outTruncate
+                          : detail::RedirectFile::Direction::out))
+    {}
     explicit Stdout(std::ostream &os) : RedirectFile(STDOUT_FILENO, os) {}
 
     friend class ProcessExecContext;


### PR DESCRIPTION
Support for not truncating file used in process output redirect, i.e. shell's `>>` redirect. Defaults to truncating redirection (`>`).