### PR TITLE
process: Added callbacks support

### DIFF
--- a/utility/identity.cpp
+++ b/utility/identity.cpp
@@ -49,7 +49,7 @@ Identity Identity::effectivePersona()
     return i;
 }
 
-Identity NamedIdentity::resolve()
+Identity NamedIdentity::resolve() const
 {
     Identity p;
     try {
@@ -77,6 +77,23 @@ Identity NamedIdentity::resolve()
     }
 
     return p;
+}
+
+void setRealPersona(const Identity &persona)
+{
+    if (setgid(persona.gid) == -1) {
+        std::system_error e(errno, std::system_category());
+        LOG(err2) << "Cannot change real gid to " << persona.gid << ": <"
+                  << e.code() << ", " << e.what() << ">.";
+        throw e;
+    }
+
+    if (setuid(persona.uid) == -1) {
+        std::system_error e(errno, std::system_category());
+        LOG(err2) << "Cannot change real uid to " << persona.uid << ": <"
+                  << e.code() << ", " << e.what() << ">.";
+        throw e;
+    }
 }
 
 void setEffectivePersona(const Identity &persona)

--- a/utility/identity.hpp
+++ b/utility/identity.hpp
@@ -54,7 +54,7 @@ struct NamedIdentity {
     std::string username;
     std::string groupname;
 
-    Identity resolve();
+    Identity resolve() const;
 };
 
 // inlines

--- a/utility/process.hpp
+++ b/utility/process.hpp
@@ -31,6 +31,7 @@
 #include <vector>
 #include <utility>
 #include <memory>
+#include <functional>
 #include <iostream>
 
 #include <boost/filesystem/path.hpp>
@@ -112,6 +113,30 @@ struct UnsetEnv {
 struct ChangeCwd {
     boost::filesystem::path wd;
     explicit ChangeCwd(const boost::filesystem::path &wd) : wd(wd) {}
+};
+
+/** Replaces positional argument with result of given function.
+ */
+struct ReplaceArg {
+    using Callback = std::function<std::string()>;
+
+    Callback callback;
+
+    explicit ReplaceArg(Callback &&callback)
+        : callback(std::move(callback))
+    {}
+};
+
+/** Calls given callback juste before calling exec.
+ */
+struct PreExecCallback {
+    using Callback = std::function<void()>;
+
+    Callback callback;
+
+    explicit PreExecCallback(Callback &&callback)
+        : callback(std::move(callback))
+    {}
 };
 
 /** Execute child process and wait for its completion.
@@ -197,6 +222,10 @@ public:
     char* const* argv() const { return argv_->data(); }
 
     const Argv& args() const { return *argv_; }
+
+    /** Replaces placeholder argument with given value.
+     */
+    bool replace(const std::string &original, const std::string &value);
 
 private:
     std::shared_ptr<Argv> argv_;


### PR DESCRIPTION
1. `ReplaceArg(callback)` adds a placeholder argument that is replaced by the result of the value returned by provided callback just before program is executed
2. `PreExecCallback(callback)` registers a generic callback that is called just before program execution.