### PR TITLE
process: name override support

### DIFF
--- a/utility/detail/process.hpp
+++ b/utility/detail/process.hpp
@@ -46,6 +46,7 @@ public:
     typedef std::vector<detail::RedirectFile> Redirects;
     typedef std::map<int, int> PlaceHolders;
 
+    ProcessName::Optional processName;
     Argv argv;
     Redirects redirects;
     PlaceHolders placeHolders;
@@ -93,6 +94,8 @@ public:
         preExecCallbacks.push_back(std::move(arg.callback));
     }
 
+    void apply(const ProcessName &arg) { processName = arg; }
+
     void apply(const ProcessExecContext &arg) { *this = arg; }
 
     template <typename T>
@@ -106,6 +109,11 @@ public:
         for (const auto &arg : args) {
             apply(arg);
         }
+    }
+
+    template <typename T>
+    void apply(const boost::optional<T> &arg) {
+        if (arg) { apply(*arg); }
     }
 
     void setFdPath(int redirectIdx, const detail::RedirectFile::DstArg &arg

--- a/utility/process.cpp
+++ b/utility/process.cpp
@@ -93,6 +93,17 @@ void ProcessExecContext::setFdPath(int redirectIdx
     argv[fplaceHolders->second] = str(boost::format(format) % fd);
 }
 
+void ExecArgs::overrideProcessName(const std::string &name) {
+    if (argv_->empty()) {
+        LOGTHROW(err2, std::logic_error)
+            << "Cannot override process name in empty exec args.";
+    }
+
+    filename_ = argv_->front();
+    argv_->front() = ::strdup(name.c_str());
+}
+
+
 bool ExecArgs::replace(const std::string &original, const std::string &value)
 {
     for (auto &arg : *argv_) {
@@ -606,6 +617,7 @@ int systemImpl(const std::string &program, ProcessExecContext ctx)
     // build arguments
     ExecArgs argv;
     argv.arg(program);
+    if (ctx.processName) { argv.overrideProcessName(ctx.processName->name); }
     for (const auto &arg : ctx.argv) {
         if (arg) {
             argv.arg(*arg);

--- a/utility/process.hpp
+++ b/utility/process.hpp
@@ -127,6 +127,15 @@ struct ReplaceArg {
     {}
 };
 
+/** Replaces process name with given string.
+ */
+struct ProcessName {
+    std::string name;
+    explicit ProcessName(const std::string &name) : name(name) {}
+
+    using Optional = boost::optional<ProcessName>;
+};
+
 /** Calls given callback juste before calling exec.
  */
 struct PreExecCallback {
@@ -218,7 +227,11 @@ public:
     template <typename T1, typename T2>
     void operator()(const T1 &a1, const T2 &a2) { arg(a1); arg(a2); }
 
-    const char* filename() const { return argv_->front(); }
+    void overrideProcessName(const std::string &name);
+
+    const char* filename() const {
+        return (filename_ ? filename_->c_str() : argv_->front());
+    }
     char* const* argv() const { return argv_->data(); }
 
     const Argv& args() const { return *argv_; }
@@ -228,6 +241,7 @@ public:
     bool replace(const std::string &original, const std::string &value);
 
 private:
+    boost::optional<std::string> filename_;
     std::shared_ptr<Argv> argv_;
 };
 


### PR DESCRIPTION
1. process name (argv[0]) can be overridden
2. optional argument support -- used only non-none
