### PR TITLE
Added utility::FileMatch::pathname flag match '/' only againt another '/'

### DIFF
--- a/utility/detail/path.posix.cpp
+++ b/utility/detail/path.posix.cpp
@@ -52,6 +52,10 @@ bool match(const std::string &globPattern
         fnFlags |= FNM_CASEFOLD;
     }
 
+    if (flags & FileMatch::pathname) {
+        fnFlags |= FNM_PATHNAME;
+    }
+
     auto res(::fnmatch(globPattern.c_str(), path.string().c_str(), fnFlags));
 
     if (!res) { return true; }

--- a/utility/path.hpp
+++ b/utility/path.hpp
@@ -143,6 +143,7 @@ cutPathPrefix(const boost::filesystem::path &path
 namespace FileMatch {
     enum {
         icase = 0x1   //!< case-insensitive matching
+        , pathname = 0x2   //!< match '/' only against '/'
     };
 }
 


### PR DESCRIPTION
Uses `FNM_PATHNAME` under the hood.