### PR TITLE
Windows updates

### DIFF
--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -1,5 +1,5 @@
 # bump version here
-set(utility_VERSION 1.43)
+set(utility_VERSION 1.44)
 
 set(utility_DEPENDS
   dbglog>=1.7

--- a/utility/detail/filesystem.windows.cpp
+++ b/utility/detail/filesystem.windows.cpp
@@ -57,7 +57,7 @@ FileId FileId::from(const boost::filesystem::path &path
     struct ::_stat s;
 
     if (-1 == ::_stat(path.string().c_str(), &s)) {
-        ec.assign(errno, std::system_category());
+        ec.assign(errno, boost::system::system_category());
         return FileId(0, 0);
     }
 
@@ -70,7 +70,7 @@ FileStat FileStat::from(const boost::filesystem::path &path)
 
     if (-1 == ::_stat(path.string().c_str(), &s)) {
         std::system_error e
-            (errno, std::system_category()
+            (errno, boost::system::system_category()
              , formatError("Cannot stat file %s.", path));
         LOG(err1) << e.what();
         throw e;
@@ -96,7 +96,7 @@ FileStat FileStat::from(int fd)
 
     if (-1 == ::_fstat(fd, &s)) {
         std::system_error e
-            (errno, std::system_category()
+            (errno, boost::system::system_category()
              , formatError("Cannot stat fd %d.", fd));
         LOG(err1) << e.what();
         throw e;
@@ -121,7 +121,7 @@ std::time_t lastModified(const boost::filesystem::path &path)
     struct ::_stat buf;
     if (-1 == ::_stat(path.string().c_str(), &buf)) {
         std::system_error e
-            (errno, std::system_category()
+            (errno, boost::system::system_category()
              , formatError("Cannot stat file %s.", path));
         LOG(err1) << e.what();
         throw e;
@@ -134,7 +134,7 @@ std::size_t fileSize(const boost::filesystem::path &path)
     struct ::_stat buf;
     if (-1 == ::_stat(path.string().c_str(), &buf)) {
         std::system_error e
-            (errno, std::system_category()
+            (errno, boost::system::system_category()
              , formatError("Cannot stat file %s.", path));
         LOG(err1) << e.what();
         throw e;

--- a/utility/filesystem.cpp
+++ b/utility/filesystem.cpp
@@ -168,12 +168,8 @@ std::map<std::string, fs::path> scanDir(const fs::path &root)
 
         const auto &path(iroot->path());
         const auto local(cutPathPrefix(path, root));
-        const auto id((local.parent_path() / local.stem())
-#ifdef _WIN32
-            .generic_string()); // force use of forward slashes as path separator, cpp17
-#else
-            .string());
-#endif
+        const auto id((local.parent_path() / local.stem()).generic_string());
+
         map[id] = local;
     }
 

--- a/utility/filesystem.cpp
+++ b/utility/filesystem.cpp
@@ -168,7 +168,12 @@ std::map<std::string, fs::path> scanDir(const fs::path &root)
 
         const auto &path(iroot->path());
         const auto local(cutPathPrefix(path, root));
-        const auto id((local.parent_path() / local.stem()).string());
+        const auto id((local.parent_path() / local.stem())
+#ifdef _WIN32
+            .generic_string()); // force use of forward slashes as path separator, cpp17
+#else
+            .string());
+#endif
         map[id] = local;
     }
 

--- a/utility/filesystem.cpp
+++ b/utility/filesystem.cpp
@@ -154,9 +154,9 @@ void processFile( const boost::filesystem::path &from
     of.close();
 }
 
-std::map<std::string, fs::path> scanDir(const fs::path &root)
+std::vector<fs::path> scanDir(const fs::path &root)
 {
-    std::map<std::string, fs::path> map;
+    std::vector<fs::path> results;
 
     for (fs::recursive_directory_iterator
              iroot(root, fs::symlink_option::recurse)
@@ -168,12 +168,20 @@ std::map<std::string, fs::path> scanDir(const fs::path &root)
 
         const auto &path(iroot->path());
         const auto local(cutPathPrefix(path, root));
-        const auto id((local.parent_path() / local.stem()).generic_string());
 
-        map[id] = local;
+        results.emplace_back(local);
     }
 
-    return map;
+    return results;
+}
+
+std::map<std::string, fs::path> id2path(const std::vector<fs::path> &localPaths)
+    std::map<std::string, fs::path> result;
+    for (const auto & local : localPaths) {
+        const auto id((local.parent_path() / local.stem()).generic_string());
+        result[id] = local;
+    }
+    return result;
 }
 
 } // namespace utility

--- a/utility/filesystem.cpp
+++ b/utility/filesystem.cpp
@@ -176,7 +176,7 @@ std::vector<fs::path> scanDir(const fs::path &root)
     return results;
 }
 
-std::map<std::string, fs::path> id2path(const std::vector<fs::path> &localPaths)
+std::map<std::string, fs::path> id2path(const std::vector<fs::path> &localPaths) {
     std::map<std::string, fs::path> result;
     for (const auto & local : localPaths) {
         const auto id((local.parent_path() / local.stem()).generic_string());

--- a/utility/filesystem.hpp
+++ b/utility/filesystem.hpp
@@ -67,8 +67,12 @@ std::time_t lastModified(const boost::filesystem::path &path);
 
 std::size_t fileSize(const boost::filesystem::path &path);
 
-std::map<std::string, boost::filesystem::path> scanDir(
-    const boost::filesystem::path& root);
+// scan directory recursively and return local paths relative to root
+std::vector<boost::filesystem::path>
+    scanDir(const boost::filesystem::path& root);
+
+std::map<std::string, boost::filesystem::path>
+    id2path(const std::vector<boost::filesystem::path>& localPaths);
 
 /** Generalized file ID. Wrapper around file devide/inode. Using uint64 to
  *  capture every possibility.

--- a/utility/path.cpp
+++ b/utility/path.cpp
@@ -94,12 +94,15 @@ fs::path lexically_relative(const fs::path &path, const fs::path &base)
 void rename(const fs::path& oldPath, const fs::path& newPath)
 {
 #ifdef _WIN32
-    // use copy/delete instead of problematic rename
-    auto copyOptions(fs::copy_options::recursive
-                     | fs::copy_options::overwrite_existing
-                     | fs::copy_options::copy_symlinks);
-    copy(oldPath, newPath, copyOptions);
-    remove_all(oldPath);
+    if (oldPath != newPath)
+    {
+        // use copy/delete instead of problematic rename
+        auto copyOptions(fs::copy_options::recursive
+                         | fs::copy_options::overwrite_existing
+                         | fs::copy_options::copy_symlinks);
+        copy(oldPath, newPath, copyOptions);
+        remove_all(oldPath);
+    }
 #else
     fs::rename(oldPath, newPath);
 #endif

--- a/utility/path.cpp
+++ b/utility/path.cpp
@@ -25,6 +25,7 @@
  */
 
 #include <algorithm>
+#include <boost/filesystem.hpp>
 
 #include "path.hpp"
 
@@ -89,5 +90,19 @@ fs::path lexically_relative(const fs::path &path, const fs::path &base)
 }
 
 #endif
+
+void rename(const fs::path& oldPath, const fs::path& newPath)
+{
+#ifdef _WIN32
+    // use copy/delete instead of problematic rename
+    auto copyOptions(fs::copy_options::recursive
+                     | fs::copy_options::overwrite_existing
+                     | fs::copy_options::copy_symlinks);
+    copy(oldPath, newPath, copyOptions);
+    remove_all(oldPath);
+#else
+    fs::rename(oldPath, newPath);
+#endif
+}
 
 } // namespace utility

--- a/utility/path.hpp
+++ b/utility/path.hpp
@@ -241,6 +241,9 @@ boost::filesystem::path
 lexically_relative(const boost::filesystem::path &path
                    , const boost::filesystem::path &base);
 
+void rename(const boost::filesystem::path& oldPath,
+            const boost::filesystem::path& newPath);
+
 } // namespace utility
 
 #endif // utility_path_hpp_included_


### PR DESCRIPTION
This is breaking change. For compatibility use:
`utility::scanDir(dir) -> utility::id2path(utility::scanDir(dir))`