### PR TITLE
added custom implementation of std::is_invocable for C++14, used in utiluty::Expected

### DIFF
--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -1,5 +1,5 @@
 # bump version here
-set(utility_VERSION 1.44)
+set(utility_VERSION 1.45)
 
 set(utility_DEPENDS
   dbglog>=1.7

--- a/utility/compat/optional.hpp
+++ b/utility/compat/optional.hpp
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2023 Melown Technologies SE
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * *  Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef utility_compat_optional_included_
+#define utility_compat_optional_included_
+
+/** Compatibility layer between std::optional and boost::optional
+ */
+
+#include <utility>
+
+#include <optional>
+#include <boost/optional.hpp>
+
+namespace utility {
+
+template <typename T>
+std::optional<T> compat(boost::optional<T> value)
+{
+    if (!value) { return std::nullopt; }
+    return { std::move(*value) };
+}
+
+template <typename T>
+boost::optional<T> compat(std::optional<T> value)
+{
+    if (!value) { return boost::none; }
+    return { std::move(*value) };
+}
+
+} // namespace utility
+
+#endif // utility_compat_optional_included_

--- a/utility/cppversion.hpp
+++ b/utility/cppversion.hpp
@@ -81,34 +81,4 @@ typename _Unique_if<T>::_Known_bound make_unique(Args&&...) = delete;
 
 #endif // __cpp_lib_make_unique
 
-/** Custom std::is_invocable implementation when not available (before C++17)
- *
- * Copied from https://stackoverflow.com/a/51188325/1623502 .
- *
- * NB: Code injected into the std namespace!
- */
-#ifndef __cpp_lib_is_invocable
-
-namespace std {
-
-template <typename F, typename... Args>
-struct is_invocable :
-    std::is_constructible<
-        std::function<void(Args ...)>
-        , std::reference_wrapper<typename std::remove_reference<F>::type>
-    >
-{};
-
-template <typename R, typename F, typename... Args>
-struct is_invocable_r :
-    std::is_constructible<
-        std::function<R(Args ...)>
-        , std::reference_wrapper<typename std::remove_reference<F>::type>
-    >
-{};
-
-} // namespace std
-
-#endif // __cpp_lib_is_invocable
-
 #endif // utility_cppversion_hpp_included_

--- a/utility/cppversion.hpp
+++ b/utility/cppversion.hpp
@@ -35,6 +35,7 @@
 #include <memory>
 #include <type_traits>
 #include <utility>
+#include <functional>
 
 #include "gccversion.hpp"
 
@@ -78,6 +79,36 @@ typename _Unique_if<T>::_Known_bound make_unique(Args&&...) = delete;
 
 } // namespace std
 
-#endif
+#endif // __cpp_lib_make_unique
+
+/** Custom std::is_invocable implementation when not available (before C++17)
+ *
+ * Copied from https://stackoverflow.com/a/51188325/1623502 .
+ *
+ * NB: Code injected into the std namespace!
+ */
+#ifndef __cpp_lib_is_invocable
+
+namespace std {
+
+template <typename F, typename... Args>
+struct is_invocable :
+    std::is_constructible<
+        std::function<void(Args ...)>
+        , std::reference_wrapper<typename std::remove_reference<F>::type>
+    >
+{};
+
+template <typename R, typename F, typename... Args>
+struct is_invocable_r :
+    std::is_constructible<
+        std::function<R(Args ...)>
+        , std::reference_wrapper<typename std::remove_reference<F>::type>
+    >
+{};
+
+} // namespace std
+
+#endif // __cpp_lib_is_invocable
 
 #endif // utility_cppversion_hpp_included_

--- a/utility/expected.hpp
+++ b/utility/expected.hpp
@@ -206,6 +206,7 @@ public:
     template <typename ErrorSink>
     bool forwardError(ErrorSink &sink, const ExpectedAsSink&) const;
 
+#ifdef __cpp_lib_is_invocable
     /** Combines forwardError(sink) and get().
      *  Returns nullptr if exception is set.
      */
@@ -223,6 +224,7 @@ public:
     get(ErrorSink &sink
         , std::enable_if_t<std::is_invocable
         <ErrorSink, const std::exception_ptr&>::value>* = 0);
+#endif // #ifdef __cpp_lib_is_invocable
 
     /** Combines forwardError(sink, ExpectedAsSink) and get().
      *  Returns nullptr if exception is set.
@@ -316,6 +318,8 @@ typename Expected<T, Traits>::reference Expected<T, Traits>::get() {
     throw std::logic_error("Expected value unset");
 }
 
+#ifdef __cpp_lib_is_invocable
+
 template <typename T, typename Traits>
 template <typename ErrorSink>
 typename Expected<T, Traits>::ConstGetPointer
@@ -355,6 +359,8 @@ Expected<T, Traits>
 
     return Traits::getPointer(value_);
 }
+
+#endif // #ifdef __cpp_lib_is_invocable
 
 template <typename T, typename Traits>
 template <typename ErrorSink>

--- a/utility/expected.hpp
+++ b/utility/expected.hpp
@@ -139,10 +139,17 @@ public:
     typedef typename Traits::ConstGetPointer ConstGetPointer;
 
     Expected() : value_() {}
-    Expected(const value_type &value) : value_(value) {}
-    Expected(const std::exception &exc): exc_(std::make_exception_ptr(exc)) {}
+
+    template <typename Exception>
+    Expected(const Exception &exc
+             , std::enable_if_t<std::is_base_of
+             <std::exception, Exception>::value>* = 0)
+        : exc_(std::make_exception_ptr(exc))
+    {}
+
     Expected(const std::exception_ptr &exc) : exc_(exc) {}
     Expected(const std::error_code &ec) : ec_(ec) {}
+    Expected(const value_type &value) : value_(value) {}
 
     template <typename ...Args> Expected(ExpectedInPlace, Args &&...args)
         : value_(Traits::inplace(std::forward<Args>(args)...))
@@ -155,6 +162,16 @@ public:
     /** Set value, unset exception and error code.
      */
     Expected<T, Traits>& set(const_reference value);
+
+    /** Set value, unset exception and error code.
+     */
+    template <typename Exception>
+    auto set(const Exception &exc
+             , std::enable_if_t<std::is_base_of
+             <std::exception, Exception>::value>* = 0)
+    {
+        return set(std::make_exception_ptr(exc));
+    }
 
     /** Set exception, unset value and errorcode.
      */

--- a/utility/expected.hpp
+++ b/utility/expected.hpp
@@ -41,6 +41,7 @@
 #include <boost/optional.hpp>
 #include <boost/utility/in_place_factory.hpp>
 
+#include "cppversion.hpp"
 #include "errorcode.hpp"
 
 namespace utility {
@@ -192,13 +193,19 @@ public:
      *  Returns nullptr if exception is set.
      */
     template <typename ErrorSink>
-    ConstGetPointer get(ErrorSink &sink) const;
+    ConstGetPointer
+    get(ErrorSink &sink
+        , std::enable_if_t<std::is_invocable
+        <ErrorSink, const std::exception_ptr&>::value>* = 0) const;
 
     /** Combines forwardError(sink) and get().
      *  Returns nullptr if exception is set.
      */
     template <typename ErrorSink>
-    GetPointer get(ErrorSink &sink);
+    GetPointer
+    get(ErrorSink &sink
+        , std::enable_if_t<std::is_invocable
+        <ErrorSink, const std::exception_ptr&>::value>* = 0);
 
     /** Combines forwardError(sink, ExpectedAsSink) and get().
      *  Returns nullptr if exception is set.
@@ -295,7 +302,10 @@ typename Expected<T, Traits>::reference Expected<T, Traits>::get() {
 template <typename T, typename Traits>
 template <typename ErrorSink>
 typename Expected<T, Traits>::ConstGetPointer
-Expected<T, Traits>::get(ErrorSink &sink) const
+Expected<T, Traits>
+::get(ErrorSink &sink
+      , std::enable_if_t<std::is_invocable
+      <ErrorSink, const std::exception_ptr&>::value>*) const
 {
     if (exc_) { sink(exc_); return Traits::NoConstGetPointer(); }
     if (ec_) { sink(ec_); return Traits::NoConstGetPointer(); }
@@ -312,7 +322,10 @@ Expected<T, Traits>::get(ErrorSink &sink) const
 template <typename T, typename Traits>
 template <typename ErrorSink>
 typename Expected<T, Traits>::GetPointer
-Expected<T, Traits>::get(ErrorSink &sink)
+Expected<T, Traits>
+::get(ErrorSink &sink
+      , std::enable_if_t<std::is_invocable
+      <ErrorSink, const std::exception_ptr&>::value>*)
 {
     if (exc_) { sink(exc_); return Traits::NoGetPointer(); }
     if (ec_) { sink(ec_); return Traits::NoGetPointer(); }

--- a/utility/iothreads.cpp
+++ b/utility/iothreads.cpp
@@ -18,7 +18,7 @@ IoThreads::~IoThreads()
     if (!workers_.empty()) { stop(); }
 }
 
-void IoThreads::start(std::size_t count)
+void IoThreads::start(std::size_t count, Callbacks callbacks)
 {
     // make sure threads are released when something goes wrong
     struct Guard {
@@ -32,7 +32,7 @@ void IoThreads::start(std::size_t count)
         const std::string &name((count > 1)
                                 ? utility::format("%s:%u", name_, id)
                                 : name_);
-        workers_.emplace_back(&IoThreads::worker, this, name);
+        workers_.emplace_back(&IoThreads::worker, this, name, id, callbacks);
     }
 
     guard.release();
@@ -49,16 +49,21 @@ void IoThreads::stop()
     }
 }
 
-void IoThreads::worker(const std::string &name)
+void IoThreads::worker(const std::string &name, std::size_t id
+                       , Callbacks callbacks)
 {
     dbglog::thread_id(name);
 
     LOG(info2) << "I/O thread spawned.";
 
+    if (callbacks.start) { callbacks.start(id); }
+
+    // is reset() call needed? what about thread safety?
     for (;; ioc_.reset()) {
         try {
             ioc_.run();
             LOG(info2) << "I/O thread terminated.";
+            if (callbacks.stop) { callbacks.stop(id); }
             return;
         } catch (const std::exception &e) {
             LOG(err3)

--- a/utility/iothreads.cpp
+++ b/utility/iothreads.cpp
@@ -54,7 +54,7 @@ void IoThreads::worker(const std::string &name, std::size_t id
 {
     dbglog::thread_id(name);
 
-    LOG(info2) << "I/O thread spawned.";
+    LOG(info1) << "I/O thread spawned.";
 
     if (callbacks.start) { callbacks.start(id); }
 
@@ -62,7 +62,7 @@ void IoThreads::worker(const std::string &name, std::size_t id
     for (;; ioc_.reset()) {
         try {
             ioc_.run();
-            LOG(info2) << "I/O thread terminated.";
+            LOG(info1) << "I/O thread terminated.";
             if (callbacks.stop) { callbacks.stop(id); }
             return;
         } catch (const std::exception &e) {

--- a/utility/mysqldb.hpp
+++ b/utility/mysqldb.hpp
@@ -26,6 +26,7 @@
 #ifndef utility_mysqldb_hpp_included_
 #define utility_mysqldb_hpp_included_
 
+#include <thread>
 #include <sstream>
 
 #if !UTILITY_HAS_MYSQL
@@ -72,11 +73,6 @@ namespace mysql {
     }
 } }
 #else
-
-// needed by sleep
-#ifndef _WIN32
-#include <unistd.h>
-#endif
 
 #include <ctime>
 #include <string>
@@ -274,11 +270,7 @@ void Tx<Connector>::open(const Db::OptionalTxIsolationLevel& isolationLevel)
                 << "Error starting transaction: <" << e.what()
                 << ">; retrying.";
             connector_->closeDb();
-#ifdef _WIN32
             std::this_thread::sleep_for(std::chrono::seconds(1));
-#else
-            sleep(1);
-#endif
         }
     }
 }
@@ -447,11 +439,7 @@ void failIfNotRestartable(const Exception &e)
         "safe to restart transaction: <" << e.what()
         << ">; retrying.";
     // sleep a bit
-#ifdef _WIN32
     std::this_thread::sleep_for(std::chrono::seconds(1));
-#else
-    sleep(1);
-#endif
 }
 
 } // detail

--- a/utility/serialization/optional.hpp
+++ b/utility/serialization/optional.hpp
@@ -1,0 +1,110 @@
+/**
+Grabbed from boost/serialization/optional.hpp and accomodated to std::optional
+ */
+
+/////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+
+// (C) Copyright 2002-4 Pavel Vozenilek .
+// Use, modification and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+// Provides non-intrusive serialization for std::optional.
+
+#ifndef utility_BOOST_SERIALIZATION_STD_OPTIONAL_HPP_
+#define utility_BOOST_SERIALIZATION_STD_OPTIONAL_HPP_
+
+#if defined(_MSC_VER)
+# pragma once
+#endif
+
+#include <optional>
+
+#include <boost/config.hpp>
+
+#include <boost/move/utility_core.hpp>
+
+#include <boost/serialization/item_version_type.hpp>
+#include <boost/serialization/split_free.hpp>
+#include <boost/serialization/level.hpp>
+#include <boost/serialization/nvp.hpp>
+#include <boost/serialization/library_version_type.hpp>
+#include <boost/type_traits/is_pointer.hpp>
+#include <boost/serialization/detail/stack_constructor.hpp>
+#include <boost/serialization/detail/is_default_constructible.hpp>
+#include <boost/serialization/force_include.hpp>
+
+// function specializations must be defined in the appropriate
+// namespace - boost::serialization
+namespace boost {
+namespace serialization {
+
+template<class Archive, class T>
+void save(
+    Archive & ar,
+    const std::optional< T > & t,
+    const unsigned int /*version*/
+){
+    // It is an inherent limitation to the serialization of optional.hpp
+    // that the underlying type must be either a pointer or must have a
+    // default constructor.  It's possible that this could change sometime
+    // in the future, but for now, one will have to work around it.  This can
+    // be done by serialization the optional<T> as optional<T *>
+    #if ! defined(BOOST_NO_CXX11_HDR_TYPE_TRAITS)
+        BOOST_STATIC_ASSERT(
+            boost::serialization::detail::is_default_constructible<T>::value
+            || boost::is_pointer<T>::value
+        );
+    #endif
+    const bool tflag(t);
+    ar << boost::serialization::make_nvp("initialized", tflag);
+    if (tflag){
+        ar << boost::serialization::make_nvp("value", *t);
+    }
+}
+
+template<class Archive, class T>
+void load(
+    Archive & ar,
+    std::optional< T > & t,
+    const unsigned int version
+){
+    bool tflag;
+    ar >> boost::serialization::make_nvp("initialized", tflag);
+    if(! tflag){
+        t.reset();
+        return;
+    }
+
+    if(0 == version){
+        boost::serialization::item_version_type item_version(0);
+        boost::serialization::library_version_type library_version(
+            ar.get_library_version()
+        );
+        if(boost::serialization::library_version_type(3) < library_version){
+            ar >> BOOST_SERIALIZATION_NVP(item_version);
+        }
+    }
+    if(!t)
+        t = T();
+    ar >> boost::serialization::make_nvp("value", *t);
+}
+
+template<class Archive, class T>
+void serialize(
+    Archive & ar,
+    std::optional< T > & t,
+    const unsigned int version
+){
+    boost::serialization::split_free(ar, t, version);
+}
+
+template<class T>
+struct version<std::optional<T> > {
+    BOOST_STATIC_CONSTANT(int, value = 1);
+};
+
+} // serialization
+} // boost
+
+#endif // utility_BOOST_SERIALIZATION_STD_OPTIONAL_HPP_


### PR DESCRIPTION
There's a `utility::Expected::get(promise<T>&)` overload that was never considered during function overload because the greedy `utility::Expected::get(ErrorSink&)` was always considered.

To allow this function to be ever called the greedy version had to be limited to be considerer only for _callable_ types. C++17 provides a [`std::is_invocable`](https://en.cppreference.com/w/cpp/types/is_invocable) predicate that can be used to limit the `ErroSink` version only for types that can be called with `const std::exception_ptr&` parameter.

However, we are still using C++14 so a custom version of `std::is_invocable` had to be made.

Test code:
```
        struct Sink {
            void operator()(const std::exception_ptr &e) {
                try {
                    std::rethrow_exception(e);
                } catch (const std::exception &exc) {
                    LOG(info4) << "EXC: " << exc.what();
                }
            };
            void operator()(const std::error_code &ec) {
                LOG(info4) << "EC: " << ec;
            };
        };

        utility::Expected<int> e;
        Sink sink;
        LOG(info4) << "111";
        e.get(sink);
        LOG(info4) << "222";
        e.set(123);
        if (const auto ptr = e.get(sink)) {
            LOG(info4) << "value: " << *ptr;
        }
        LOG(info4) << "333";
```
Output:
```
2022-11-18 16:39:33 I4 [209157(rm)]: 111 {remote.cpp:runnableJob():266}
2022-11-18 16:39:33 I4 [209157(rm)]: EXC: Expected value unset {remote.cpp:operator()():256}
2022-11-18 16:39:33 I4 [209157(rm)]: 222 {remote.cpp:runnableJob():268}
2022-11-18 16:39:33 I4 [209157(rm)]: value: 123 {remote.cpp:runnableJob():271}
2022-11-18 16:39:33 I4 [209157(rm)]: 333 {remote.cpp:runnableJob():273}
```
