### PR TITLE
One filesystem remove_all version

### DIFF
--- a/utility/detail/filesystem.windows.cpp
+++ b/utility/detail/filesystem.windows.cpp
@@ -39,14 +39,26 @@ namespace utility {
 
 FileId FileId::from(const boost::filesystem::path &path)
 {
+    boost::system::error_code ec;
+    auto fid(from(path, ec));
+    if (ec) {
+        std::system_error e
+            (ec, formatError("Cannot stat file %s.", path));
+        LOG(err1) << e.what();
+        throw e;
+    }
+
+    return fid;
+}
+
+FileId FileId::from(const boost::filesystem::path &path
+                    , boost::system::error_code &ec)
+{
     struct ::_stat s;
 
     if (-1 == ::_stat(path.string().c_str(), &s)) {
-        std::system_error e
-            (errno, std::system_category()
-             , formatError("Cannot stat file %s.", path));
-        LOG(err1) << e.what();
-        throw e;
+        ec.assign(errno, std::system_category());
+        return FileId(0, 0);
     }
 
     return FileId(s.st_dev, s.st_ino);

--- a/utility/filesystem.cpp
+++ b/utility/filesystem.cpp
@@ -181,7 +181,6 @@ namespace {
 std::size_t removeDirContentsOneFs(const fs::path &dir, std::uint64_t device
                                    , bs::error_code &ec)
 {
-    LOG(info4) << "removeDirContentsOneFs(" << dir << ")";
     std::size_t removed(0);
 
     fs::directory_iterator idir(dir);

--- a/utility/filesystem.hpp
+++ b/utility/filesystem.hpp
@@ -85,6 +85,9 @@ struct FileId {
 
     bool operator!=(const FileId &fid) const;
 
+    static FileId from(const boost::filesystem::path &path
+                       , boost::system::error_code &ec);
+
     static FileId from(const boost::filesystem::path &path);
 };
 
@@ -107,6 +110,29 @@ struct FileStat {
     static FileStat from(int fd);
     static FileStat from(int fd, std::nothrow_t);
 };
+
+struct RemoveAllFlags {
+    /** Skip any directory that is on a file system different from that of the
+     *  remove_all argument (or .device, if nonzero).
+     */
+    bool oneFileSystem = false;
+
+    /** Device number. Used only when oneFilesystem. Used instead of path's
+     ** device number if nonzero.
+     */
+    std::uint64_t device = 0;
+};
+
+/** Purge all files from path.
+ */
+std::size_t remove_all(const boost::filesystem::path &path
+                       , boost::system::error_code &ec
+                       , const RemoveAllFlags &flags = {});
+
+/** Purge all files from path.
+ */
+std::size_t remove_all(const boost::filesystem::path &path
+                       , const RemoveAllFlags &flags = {});
 
 // impelemtation
 


### PR DESCRIPTION
The`boost::filesystem::remove_all()` function happily descends into directories on other filesystems. This may cause removal of important data when mounted at the _right_ place. NB: `rm -rf` without `--one-file-system` option has the same behavior.

This MR introduces our custom function `utility::remove_all()` that accepts `utility::RemoveAllFlags`. When `utility::RemoveAllFlags::oneFilesystem` flag is set `false` then `boost::filesystem_remove_all()` is called as usual.

When the flag is set to `true` then custom code is run that check whether removed file/directory is on a filesystem other than the one referenced in `utility::RemoveAllFlags::device`. If `utility::RemoveAllFlags::device` is `0` then the device the `path` resides is used instead.