### PR TITLE
C++17: properly constructing std::future_error from std::error_code

### DIFF
--- a/utility/errorcode.hpp
+++ b/utility/errorcode.hpp
@@ -60,7 +60,7 @@ inline void throwErrorCode(const std::error_code &ec) noexcept(false)
 
 #if __cplusplus >= 201703L
     if (cat == std::future_category()) {
-        throw std::future_error(ec);
+        throw std::future_error(static_cast<std::future_errc>(ec.value()));
     }
 #endif
 
@@ -81,7 +81,7 @@ inline void throwErrorCode(const std::error_code &ec, std::string message)
 
 #if __cplusplus >= 201703L
     if (cat == std::future_category()) {
-        throw std::future_error(ec);
+        throw std::future_error(static_cast<std::future_errc>(ec.value()));
     }
 #endif
 


### PR DESCRIPTION
NB: C++17 only.

The `std::future_error` exception can be initialized only from `std::future_errc` `enum` and not directly from `std::error_code`. Error code (`std::error_code::value()`) must be cast from generic `int` to `std::future_errc` `enum`. Of course, only when `std::error_code::category()` is `std::future_category`.
