### PR TITLE
Optional id in LogThreadId

### DIFF
--- a/utility/logging.hpp
+++ b/utility/logging.hpp
@@ -27,6 +27,8 @@
 #ifndef utility_logging_hpp_included_
 #define utility_logging_hpp_included_
 
+#include <optional>
+
 #include <boost/lexical_cast.hpp>
 
 #include "dbglog/dbglog.hpp"
@@ -40,6 +42,9 @@ namespace utility {
 class LogThreadId {
 public:
     struct Append {};
+
+    LogThreadId(const std::optional<std::string> &id);
+    LogThreadId(Append, const std::optional<std::string> &id);
 
     LogThreadId(const std::string &id);
     LogThreadId(Append, const std::string &id);
@@ -66,6 +71,18 @@ private:
         (utility::LogThreadId::Append{}, __VA_ARGS__)
 
 // implementation
+
+inline LogThreadId::LogThreadId(const std::optional<std::string> &id)
+    : saved_(dbglog::thread_id())
+{
+    if (id) { dbglog::thread_id(*id); }
+}
+
+inline LogThreadId::LogThreadId(Append, const std::optional<std::string> &id)
+    : saved_(dbglog::thread_id())
+{
+    if (id) { dbglog::thread_id(saved_ + "/" + *id); }
+}
 
 inline LogThreadId::LogThreadId(const std::string &id)
     : saved_(dbglog::thread_id())

--- a/utility/logging.hpp
+++ b/utility/logging.hpp
@@ -60,7 +60,7 @@ public:
     ~LogThreadId();
 
 private:
-    std::string saved_;
+    std::optional<std::string> saved_;
 };
 
 #define UTILITY_LOGSETID(...) \
@@ -73,15 +73,19 @@ private:
 // implementation
 
 inline LogThreadId::LogThreadId(const std::optional<std::string> &id)
-    : saved_(dbglog::thread_id())
 {
-    if (id) { dbglog::thread_id(*id); }
+    if (id) {
+        saved_ = dbglog::thread_id();
+        dbglog::thread_id(*id);
+    }
 }
 
 inline LogThreadId::LogThreadId(Append, const std::optional<std::string> &id)
-    : saved_(dbglog::thread_id())
 {
-    if (id) { dbglog::thread_id(saved_ + "/" + *id); }
+    if (id) {
+        saved_ = dbglog::thread_id();
+        dbglog::thread_id(*saved_ + "/" + *id);
+    }
 }
 
 inline LogThreadId::LogThreadId(const std::string &id)
@@ -115,9 +119,11 @@ LogThreadId::LogThreadId(Append a, const T &value)
 {}
 
 inline LogThreadId::~LogThreadId() {
-    try {
-        dbglog::thread_id(saved_);
-    } catch (...) {}
+    if (saved_) {
+        try {
+            dbglog::thread_id(*saved_);
+        } catch (...) {}
+    }
 }
 
 } // namespace utility


### PR DESCRIPTION
A new `std::optional<std::string>` version sets/appends `id` only if not null.