### PR TITLE
C++17 std::variant helpers

### DIFF
--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -1,5 +1,5 @@
 # bump version here
-set(utility_VERSION 1.45)
+set(utility_VERSION 1.46)
 
 set(utility_DEPENDS
   dbglog>=1.7

--- a/utility/std-variant.hpp
+++ b/utility/std-variant.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 Melown Technologies SE
+ * Copyright (c) 2023 Melown Technologies SE
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/utility/std-variant.hpp
+++ b/utility/std-variant.hpp
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2020 Melown Technologies SE
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * *  Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef utility_std_variant_hpp_included_
+#define utility_std_variant_hpp_included_
+
+#include <utility>
+#include <variant>
+
+namespace utility {
+
+// Copied from C++ reference entry for std::visit
+// [ https://en.cppreference.com/w/cpp/utility/variant/visit ]
+
+template<typename... Ts>
+struct overloaded : Ts... {
+    using Ts::operator()...;
+};
+
+// explicit deduction guide (not needed as of C++20)
+template<typename... Ts>
+overloaded(Ts...) -> overloaded<Ts...>;
+
+template <typename T, typename... Ts>
+T& make_variant(std::variant<Ts...> &variant)
+{
+    return std::get<T>(variant = T());
+}
+
+} // namespace utility
+
+#endif // utility_std_variant_hpp_included_


### PR DESCRIPTION
Adds suport to `std::variant` (C++17) analogous to already present `boost::variant` ones:
 - `overloaded`: analogous to `make_lambda_visitor` -- joins multiple lambdas (or any callable object) into one object with overloaded `operator()`; primarily useful for `std::visit(...)`
 - `make_variant(std::variant<T>&)`: one-to-one mirror of `make_variant(boost::variant&)` 
