### PR TITLE
clang warning fixes

### DIFF
--- a/utility/detail/memoryfile.unsupported.cpp
+++ b/utility/detail/memoryfile.unsupported.cpp
@@ -29,7 +29,8 @@
 
 namespace utility {
 
-Filedes memoryFile(const std::string &name, int flags)
+Filedes memoryFile([[maybe_unused]] const std::string& name,
+                   [[maybe_unused]] int flags)
 {
     LOGTHROW(err3, std::runtime_error)
         << "In-memory file creation unsupported on this platform.";
@@ -37,4 +38,3 @@ Filedes memoryFile(const std::string &name, int flags)
 }
 
 } // namespace utility
-

--- a/utility/enum-io.hpp
+++ b/utility/enum-io.hpp
@@ -230,7 +230,8 @@
         is.setstate(std::ios::failbit);                                 \
         return is;                                                      \
     }                                                                   \
-    constexpr int enumerationValuesCount(Type) {                        \
+    UTILITY_POSSIBLY_UNUSED constexpr int enumerationValuesCount(Type)  \
+    {                                                                   \
         return BOOST_PP_SEQ_SIZE(seq);                                  \
     }                                                                   \
     std::array<Type, BOOST_PP_SEQ_SIZE(seq)>                            \

--- a/utility/runnable.hpp
+++ b/utility/runnable.hpp
@@ -35,7 +35,7 @@ namespace utility {
 class Runnable : boost::noncopyable {
 public:
     Runnable() = default;
-    Runnable(Runnable &&) = default;
+    // Runnable(Runnable &&) = default; // move ctor deleted in noncopyable
     virtual ~Runnable() {}
     virtual bool isRunning() = 0;
     virtual void stop() = 0;

--- a/utility/thread.cpp
+++ b/utility/thread.cpp
@@ -34,7 +34,7 @@
 
 namespace utility { namespace thread {
 
-void setName(const std::string &name)
+void setName([[maybe_unused]] const std::string &name)
 {
 #if defined(_GNU_SOURCE) && !defined(__llvm__)
     auto useName((name.size() > 15) ? name.substr(0, 15) : name);
@@ -48,7 +48,7 @@ void setName(const std::string &name)
 #endif
 }
 
-void appendName(const std::string &name)
+void appendName([[maybe_unused]] const std::string &name)
 {
 #if defined(_GNU_SOURCE) && !defined(__llvm__)
     // fetch original name


### PR DESCRIPTION
note the move ctor implicitly deleted in boost::noncopyable